### PR TITLE
Исправлено определение параметров при многострочном заголовке функции.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -165,8 +165,8 @@ SyntaxAnalysis.prototype.AnalyseModule = function (sourceCode, initValueTable, t
                         i++;
                         while (i<n) {
                             str = this.AnalyseComments(Lines[i]);
-                            if ((Matches = this.RE_PARAM_END.exec(str))!=null) {
-                                strParams = strParams+"\n"+Matches[1]
+                            if ((Matches = this.RE_PARAM_END.exec(strParams+"\n"+str))!=null) {
+                                strParams = Matches[1];
                                 break;
                             } else {
                                 strParams = strParams+"\n"+str;


### PR DESCRIPTION
Исправляет включение ключевого слова Функция/Процедура как первый параметр метода
